### PR TITLE
Update to consider new function names.

### DIFF
--- a/audio2text/AudioAnalytics.ipynb
+++ b/audio2text/AudioAnalytics.ipynb
@@ -948,7 +948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "0ecf3920",
    "metadata": {},
    "outputs": [
@@ -989,7 +989,7 @@
     "        \n",
     "        from Audio_Claims_Extracted_info\n",
     "        )\n",
-    "        select OBJECT_CONSTRUCT(*) as audio_data, SNOWFLAKE.CORTEX.embed_text('e5-base-v2' ,\n",
+    "        select OBJECT_CONSTRUCT(*) as audio_data, SNOWFLAKE.CORTEX.embed_text_768('e5-base-v2' ,\n",
     "        audio_data::string) as ct_embedding from sub ;\n",
     "                    \n",
     "            ''').collect()"

--- a/audio2text/audio2text_setup_code.ipynb
+++ b/audio2text/audio2text_setup_code.ipynb
@@ -219,7 +219,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Wait for the service to be in Ready State before moving ahead. Run the below command to confirm it"
+    "> Wait for the service to be in Ready State before moving ahead. Run the below command to confirm it. If compute pool is not running you can resume it using the following command:\n",
+    "```sql\n",
+    "ALTER COMPUTE POOL PR_GPU_S RESUME\n",
+    "```"
    ]
   },
   {

--- a/streamlit/src/Chatbot.py
+++ b/streamlit/src/Chatbot.py
@@ -56,7 +56,7 @@ def chatbot(session:Session):
     model = st.selectbox("Hello, I'm the Snowflake Cortex Vehicle Insurance AI Assistant based on Llama v2. Please choose the model you'd like to use:", options = ['llama2-70b-chat','llama2-7b-chat'])
 
     def get_context(question):
-        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_distance(ct_embedding ,SNOWFLAKE.CORTEX.embed_text_768('e5-base-v2',
+        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_similarity(ct_embedding ,SNOWFLAKE.CORTEX.embed_text_768('e5-base-v2',
         '{question}')) as similarity from Audio_Call_Embedding 
         order by similarity desc limit 1) select AUDIO_DATA 
         from top_response;'''
@@ -65,7 +65,7 @@ def chatbot(session:Session):
         return df['AUDIO_DATA'][0]
 
     def get_df(question):
-        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_distance(ct_embedding ,SNOWFLAKE.CORTEX.embed_text_768('e5-base-v2',
+        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_similarity(ct_embedding ,SNOWFLAKE.CORTEX.embed_text_768('e5-base-v2',
         '{question}')) as similarity from Audio_Call_Embedding 
         order by similarity desc limit 3) 
         select AUDIO_DATA:AUDIOFILENAME::string as AudioFileName,AUDIO_DATA:CALLDATE::date as CallDate,AUDIO_DATA:CALLSENTIMENT::string  as Sentiment

--- a/streamlit/src/Chatbot.py
+++ b/streamlit/src/Chatbot.py
@@ -56,7 +56,7 @@ def chatbot(session:Session):
     model = st.selectbox("Hello, I'm the Snowflake Cortex Vehicle Insurance AI Assistant based on Llama v2. Please choose the model you'd like to use:", options = ['llama2-70b-chat','llama2-7b-chat'])
 
     def get_context(question):
-        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_distance(ct_embedding ,SNOWFLAKE.CORTEX.embed_text('e5-base-v2',
+        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_distance(ct_embedding ,SNOWFLAKE.CORTEX.embed_text_768('e5-base-v2',
         '{question}')) as similarity from Audio_Call_Embedding 
         order by similarity desc limit 1) select AUDIO_DATA 
         from top_response;'''
@@ -65,7 +65,7 @@ def chatbot(session:Session):
         return df['AUDIO_DATA'][0]
 
     def get_df(question):
-        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_distance(ct_embedding ,SNOWFLAKE.CORTEX.embed_text('e5-base-v2',
+        sql_stmt = f''' with top_response as ( select AUDIO_DATA, vector_cosine_distance(ct_embedding ,SNOWFLAKE.CORTEX.embed_text_768('e5-base-v2',
         '{question}')) as similarity from Audio_Call_Embedding 
         order by similarity desc limit 3) 
         select AUDIO_DATA:AUDIOFILENAME::string as AudioFileName,AUDIO_DATA:CALLDATE::date as CallDate,AUDIO_DATA:CALLSENTIMENT::string  as Sentiment


### PR DESCRIPTION
Following updates done to code in order to make sure sfguide run appropriately.
- Use of SNOWFLAKE.CORTEX.embed_text_768 instead of SNOWFLAKE.CORTEX.embed_text in  audio2text/AudioAnalytics.ipynb  and streamlit/src/Chatbot.py
- Suggest use of "ALTER COMPUTE POOL PR_GPU_S RESUME" when running service in audio2text/audio2text_setup_code.ipynb
- Use of vector_cosine_similarity instead of vector_cosine_distance in streamlit/src/Chatbot.py